### PR TITLE
Update Azure-Vote sample with new billing model using pod release id label

### DIFF
--- a/samples/k8s-offer-azure-vote/azure-vote/templates/deployments.yaml
+++ b/samples/k8s-offer-azure-vote/azure-vote/templates/deployments.yaml
@@ -1,9 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vote-back-{{.Release.Name}}
-  labels:
-    billing: {{ .Values.global.azure.billingIdentifier }}
+  name: vote-back-{{.Release.Name}} 
 spec:
   replicas: 1
   selector:
@@ -13,6 +11,7 @@ spec:
     metadata:
       labels:
         app: vote-back-{{.Release.Name}}
+        azure-extensions-usage-release-identifier: {{.Release.Name}}
     spec:
       containers:
       - name: vote-back-{{.Release.Name}}
@@ -33,8 +32,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote-front-{{.Release.Name}}
-  labels:
-    billing: {{ .Values.global.azure.billingIdentifier }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -49,6 +46,7 @@ spec:
     metadata:
       labels:
         app: vote-front-{{.Release.Name}}
+        azure-extensions-usage-release-identifier: {{.Release.Name}}        
     spec:
       containers:
       - name: vote-front

--- a/samples/k8s-offer-azure-vote/azure-vote/values.yaml
+++ b/samples/k8s-offer-azure-vote/azure-vote/values.yaml
@@ -4,7 +4,6 @@ value1: Cats
 value2: Dogs
 global:
   azure:
-    billingIdentifier: DONOTMODIFY
     images:
       frontend:
         digest: sha256:b9ce27930c8bc8457fcf2e16a078b03fe78f19d7fefd0c60acf17923d5388ef7


### PR DESCRIPTION
Update Azure-Vote sample with new billing model using pod release id label
- removed redundant billing label from deployment spec
- removed redundant billingIdentifier from values.yaml
- added new label 'azure-extesnsion-usage-release-identifier' on pod spec