### PR TITLE
Set allowExisting for resource-group to be always true in CreateUiDef

### DIFF
--- a/samples/k8s-offer-azure-vote/createUIDefinition.json
+++ b/samples/k8s-offer-azure-vote/createUIDefinition.json
@@ -15,7 +15,7 @@
 					]
 				},
 				"resourceGroup": {
-					"allowExisting": "[equals(basics('createNewCluster'), false)]"
+					"allowExisting": true
 				}
 			}
 		},

--- a/samples/k8s-offer-azure-vote/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote/mainTemplate.json
@@ -195,7 +195,7 @@
         },  
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2022-04-02-preview",
+            "apiVersion": "2022-11-01",
             "name": "[parameters('extensionResourceName')]",          
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/k8s-offer-azure-vote/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote/mainTemplate.json
@@ -138,7 +138,7 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition" : "[parameters('createNewCluster')]",
-            "apiVersion": "2022-03-01",
+            "apiVersion": "2022-11-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],


### PR DESCRIPTION
## Purpose

Update CreateUiDef sample to recommend setting resourceGroup.allowExisting to be always true.
This setting would allow using non-empty resource group for deployments

Also update the api version for AKS and extension resources to 2011-11-01

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[X ] Documentation content changes
[ ] Other... Please describe:
```
