### PR TITLE
Refresh redis image to use alpine 7.0.12

### DIFF
--- a/samples/k8s-offer-azure-vote-custom-meters/azure-vote-custom/values.yaml
+++ b/samples/k8s-offer-azure-vote-custom-meters/azure-vote-custom/values.yaml
@@ -21,7 +21,7 @@ global:
         image: azure-vote-custom-front
         registry: azurek8ssamples.azurecr.io/marketplaceimages
       backend:
-        digest: sha256:9c8c3268cbe8925e2e4485ca0e48a42ff82393e2ec4c4026534fe3f4dd7d6786
+        digest: sha256:e600a259cb3ef2c6ceace477022d6159c3e72763c694d54c0263365101de3266
         image: azure-vote-back
         registry: azurek8ssamples.azurecr.io/marketplaceimages
 # how many frontends do we want?

--- a/samples/k8s-offer-azure-vote/azure-vote/values.yaml
+++ b/samples/k8s-offer-azure-vote/azure-vote/values.yaml
@@ -10,7 +10,7 @@ global:
         image: azure-vote-front
         registry: azurek8ssamples.azurecr.io/marketplaceimages
       backend:
-        digest: sha256:9c8c3268cbe8925e2e4485ca0e48a42ff82393e2ec4c4026534fe3f4dd7d6786
+        digest: sha256:e600a259cb3ef2c6ceace477022d6159c3e72763c694d54c0263365101de3266
         image: azure-vote-back
         registry: azurek8ssamples.azurecr.io/marketplaceimages
 # how many frontends do we want?


### PR DESCRIPTION
Existing latest redis contains vulnerabilities. Since azure vote is compatible with alpine version, we are switching the image to minimize issue: https://alpinelinux.org/