### PR TITLE
Update image references for Azure Vote app

### DIFF
--- a/samples/k8s-offer-azure-vote-custom-meters/azure-vote-custom/values.yaml
+++ b/samples/k8s-offer-azure-vote-custom-meters/azure-vote-custom/values.yaml
@@ -17,13 +17,13 @@ global:
       resourceId: "DONOTMODIFY" # application's Azure Resource ID, Azure populates this value at deployment time
     images:
       frontend:
-        tag: "1.0.22"
-        image: azure-vote-custom-front
+        tag: latest
+        image: azure-vote-front
         registry: azurek8ssamples.azurecr.io/marketplaceimages
       backend:
-        tag: "latest"
-        image: azure-vote-back
-        registry: azurek8ssamples.azurecr.io/marketplaceimages
+        tag: alpine
+        image: redis
+        registry: docker.io/library
 # how many frontends do we want?
 replicaCount: 1
 

--- a/samples/k8s-offer-azure-vote/azure-vote/values.yaml
+++ b/samples/k8s-offer-azure-vote/azure-vote/values.yaml
@@ -6,13 +6,13 @@ global:
   azure:
     images:
       frontend:
-        tag: "1.0.8"
+        tag: latest
         image: azure-vote-front
         registry: azurek8ssamples.azurecr.io/marketplaceimages
       backend:
-        tag: "latest"
-        image: azure-vote-back
-        registry: azurek8ssamples.azurecr.io/marketplaceimages
+        tag: alpine
+        image: redis
+        registry: docker.io/library
 # how many frontends do we want?
 replicaCount: 1
 


### PR DESCRIPTION
Update image references for Azure Vote app.
The front-end image will always use the latest tag. The backend image will now pull redis alpine image docker repository.