### PR TITLE
Update Kubernetes version to 1.32.6 and remove HTTP application routing from multiple ARM templates

### DIFF
--- a/samples/datatype-sample/mainTemplate.json
+++ b/samples/datatype-sample/mainTemplate.json
@@ -203,7 +203,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/datatype-sample/mainTemplate.json
+++ b/samples/datatype-sample/mainTemplate.json
@@ -114,20 +114,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -172,7 +158,7 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition": "[parameters('createNewCluster')]",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-04-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],
@@ -217,20 +203,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/datatype-sample/mainTemplate.json
+++ b/samples/datatype-sample/mainTemplate.json
@@ -84,7 +84,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -112,13 +112,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -185,7 +178,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -195,6 +188,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -223,9 +220,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/dynamic-configuration-settings-sample/mainTemplate.json
+++ b/samples/dynamic-configuration-settings-sample/mainTemplate.json
@@ -108,20 +108,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -169,7 +155,7 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition": "[parameters('createNewCluster')]",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-04-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],
@@ -214,20 +200,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/dynamic-configuration-settings-sample/mainTemplate.json
+++ b/samples/dynamic-configuration-settings-sample/mainTemplate.json
@@ -78,7 +78,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -106,13 +106,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -182,7 +175,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -192,6 +185,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -220,9 +217,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/dynamic-configuration-settings-sample/mainTemplate.json
+++ b/samples/dynamic-configuration-settings-sample/mainTemplate.json
@@ -200,7 +200,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/k8s-connectedcluster-only/mainTemplate.json
+++ b/samples/k8s-connectedcluster-only/mainTemplate.json
@@ -34,7 +34,7 @@
     "resources": [
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/k8s-existing-cluster-only-sample/mainTemplate.json
+++ b/samples/k8s-existing-cluster-only-sample/mainTemplate.json
@@ -25,7 +25,7 @@
     "resources": [
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "dependsOn": [
             ],

--- a/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
@@ -173,7 +173,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
@@ -105,20 +105,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "azurelinux",
@@ -142,7 +128,7 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition": "[parameters('createNewCluster')]",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-04-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],
@@ -187,20 +173,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote-custom-meters/mainTemplate.json
@@ -75,7 +75,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -103,13 +103,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -155,7 +148,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -165,6 +158,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -193,9 +190,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/k8s-offer-azure-vote/azure-vote/src/Dockerfile
+++ b/samples/k8s-offer-azure-vote/azure-vote/src/Dockerfile
@@ -1,6 +1,4 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
-
-RUN tdnf install -y python3-pip
+FROM mcr.microsoft.com/azurelinux/base/python:3.12
 
 # We copy just the requirements.txt first to leverage Docker cache
 COPY ./requirements.txt /app/requirements.txt
@@ -11,4 +9,5 @@ RUN pip install -r requirements.txt
 
 COPY . /app
 
-ENTRYPOINT FLASK_APP=/app/main.py flask run --host=0.0.0.0 --port=80
+ENV FLASK_APP=/app/main.py
+ENTRYPOINT ["flask", "run", "--host=0.0.0.0", "--port=80"]

--- a/samples/k8s-offer-azure-vote/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote/mainTemplate.json
@@ -75,13 +75,13 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
         },
         "networkPlugin": {
-            "defaultValue": "kubenet",
+            "defaultValue": "azure",
             "allowedValues": [
                 "azure",
                 "kubenet"
@@ -103,13 +103,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -156,13 +149,13 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition": "[parameters('createNewCluster')]",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-05-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -172,6 +165,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -184,7 +181,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,
@@ -201,9 +197,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },
@@ -215,7 +208,7 @@
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/k8s-offer-azure-vote/mainTemplate.json
+++ b/samples/k8s-offer-azure-vote/mainTemplate.json
@@ -105,20 +105,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -195,14 +181,6 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },

--- a/samples/managed-app-sample/mainTemplate.json
+++ b/samples/managed-app-sample/mainTemplate.json
@@ -178,7 +178,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/managed-app-sample/mainTemplate.json
+++ b/samples/managed-app-sample/mainTemplate.json
@@ -69,7 +69,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -97,13 +97,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Boolean flag to turn on and off private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -156,7 +149,7 @@
             ],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -170,6 +163,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -198,9 +195,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/managed-app-sample/mainTemplate.json
+++ b/samples/managed-app-sample/mainTemplate.json
@@ -99,20 +99,6 @@
                 "description": "Boolean flag to turn on and off private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -141,7 +127,7 @@
         },
         {
             "type": "Microsoft.ContainerService/managedClusters",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-04-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [
@@ -192,20 +178,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/override-namespace-sample/clusterscope-mainTemplate.json
+++ b/samples/override-namespace-sample/clusterscope-mainTemplate.json
@@ -105,20 +105,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -191,20 +177,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/override-namespace-sample/clusterscope-mainTemplate.json
+++ b/samples/override-namespace-sample/clusterscope-mainTemplate.json
@@ -177,7 +177,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/override-namespace-sample/clusterscope-mainTemplate.json
+++ b/samples/override-namespace-sample/clusterscope-mainTemplate.json
@@ -75,7 +75,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -103,13 +103,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -159,7 +152,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -169,6 +162,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -197,9 +194,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/override-namespace-sample/namespacescope-mainTemplate.json
+++ b/samples/override-namespace-sample/namespacescope-mainTemplate.json
@@ -105,20 +105,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -191,20 +177,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/override-namespace-sample/namespacescope-mainTemplate.json
+++ b/samples/override-namespace-sample/namespacescope-mainTemplate.json
@@ -177,7 +177,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/override-namespace-sample/namespacescope-mainTemplate.json
+++ b/samples/override-namespace-sample/namespacescope-mainTemplate.json
@@ -75,7 +75,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -103,13 +103,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -159,7 +152,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -169,6 +162,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -197,9 +194,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },

--- a/samples/select-auto-upgrade-minor-version/mainTemplate.json
+++ b/samples/select-auto-upgrade-minor-version/mainTemplate.json
@@ -180,7 +180,6 @@
                         "vmSize": "[parameters('vmSize')]",
                         "osType": "Linux",
                         "osSKU": "[parameters('osSKU')]",
-                        "storageProfile": "ManagedDisks",
                         "type": "VirtualMachineScaleSets",
                         "mode": "System",
                         "maxPods": 110,

--- a/samples/select-auto-upgrade-minor-version/mainTemplate.json
+++ b/samples/select-auto-upgrade-minor-version/mainTemplate.json
@@ -112,20 +112,6 @@
                 "description": "Enable private network access to the Kubernetes cluster."
             }
         },
-        "enableAzurePolicy": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off Azure Policy addon."
-            }
-        },
-        "enableSecretStoreCSIDriver": {
-            "defaultValue": false,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off secret store CSI driver."
-            }
-        },
         "osSKU": {
             "type": "string",
             "defaultValue": "AzureLinux",
@@ -149,7 +135,7 @@
         {
             "type": "Microsoft.ContainerService/managedClusters",
             "condition": "[parameters('createNewCluster')]",
-            "apiVersion": "2024-05-01",
+            "apiVersion": "2025-04-01",
             "name": "[parameters('clusterResourceName')]",
             "location": "[parameters('location')]",
             "dependsOn": [],
@@ -194,20 +180,12 @@
                 },
                 "apiServerAccessProfile": {
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
-                },
-                "addonProfiles": {
-                    "azurepolicy": {
-                        "enabled": "[parameters('enableAzurePolicy')]"
-                    },
-                    "azureKeyvaultSecretsProvider": {
-                        "enabled": "[parameters('enableSecretStoreCSIDriver')]"
-                    }
                 }
             }
         },
         {
             "type": "Microsoft.KubernetesConfiguration/extensions",
-            "apiVersion": "2023-05-01",
+            "apiVersion": "2024-11-01",
             "name": "[parameters('extensionResourceName')]",
             "properties": {
                 "extensionType": "[variables('clusterExtensionTypeName')]",

--- a/samples/select-auto-upgrade-minor-version/mainTemplate.json
+++ b/samples/select-auto-upgrade-minor-version/mainTemplate.json
@@ -82,7 +82,7 @@
         },
         "kubernetesVersion": {
             "type": "String",
-            "defaultValue": "1.26.3",
+            "defaultValue": "1.32.6",
             "metadata": {
                 "description": "The version of Kubernetes."
             }
@@ -110,13 +110,6 @@
             "type": "Bool",
             "metadata": {
                 "description": "Enable private network access to the Kubernetes cluster."
-            }
-        },
-        "enableHttpApplicationRouting": {
-            "defaultValue": true,
-            "type": "Bool",
-            "metadata": {
-                "description": "Boolean flag to turn on and off http application routing."
             }
         },
         "enableAzurePolicy": {
@@ -162,7 +155,7 @@
             "dependsOn": [],
             "tags": {},
             "sku": {
-                "name": "Basic",
+                "name": "Base",
                 "tier": "Free"
             },
             "identity": {
@@ -172,6 +165,10 @@
                 "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "enableRBAC": "[parameters('enableRBAC')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
+                "autoUpgradeProfile": {
+                    "upgradeChannel": "patch",
+                    "nodeOSUpgradeChannel": "NodeImage"
+                },
                 "agentPoolProfiles": [
                     {
                         "name": "agentpool",
@@ -200,9 +197,6 @@
                     "enablePrivateCluster": "[parameters('enablePrivateCluster')]"
                 },
                 "addonProfiles": {
-                    "httpApplicationRouting": {
-                        "enabled": "[parameters('enableHttpApplicationRouting')]"
-                    },
                     "azurepolicy": {
                         "enabled": "[parameters('enableAzurePolicy')]"
                     },


### PR DESCRIPTION


## Purpose
Update Kubernetes version to 1.32.6 and remove HTTP application routing from multiple ARM templates

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->